### PR TITLE
Must explicitely use the 'check' package

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use(['underscore','coffeescript','matb33:collection-hooks@0.7.6']);
+  api.use(['underscore','coffeescript', 'check', 'matb33:collection-hooks@0.7.6']);
   api.versionsFrom('1.0');
   api.addFiles('slugs.coffee');
 });


### PR DESCRIPTION
When using friendly-slugs within a package, I got a `ReferenceError: Match is not defined` until I made this change.
