### PR TITLE
Slug distinct up to a list of fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Option | Default | Description
 slugFrom | 'name' | Name of field you want to base the slug from. *String*
 slugField | 'slug' | Name of field you want the slug to be stored to. *String*
 distinct | true |  True = Slugs are unique, if 'foo' is already a stored slug for another item, the new item's slug will be 'foo-1' False = Slugs will not be unique, items can have the same slug as another item in the same collection. *Boolean*
+distinctUpTo | [] | if distinct = true list of fields of the collection that define the validity range of the distinction
 updateSlug | true | True = Update the item's slug if the slugField's content changes in an update. False = Slugs do not change when the slugField changes. *Boolean*
 createOnUpdate | true | True = If an item is updated and the slug has not been created yet and the slugField has not changed, create the slug during the update False = Slugs will not be created during an update unless updateSlug = true in your settings and the slugField has changed. *Boolean*
 transliteration | see default array in [Transliteration](#transliteration) | Translates characters with accents to URL compatible characters, see [Transliteration](#transliteration) for more info.

--- a/slugs.coffee
+++ b/slugs.coffee
@@ -19,6 +19,7 @@ Mongo.Collection.prototype.friendlySlugs = (options = {}) ->
       slugFrom: 'name'
       slugField: 'slug'
       distinct: true
+      distinctUpTo: []
       updateSlug: true
       createOnUpdate: true
       debug: false
@@ -160,6 +161,12 @@ Mongo.Collection.prototype.friendlySlugs = (options = {}) ->
 
       fieldSelector = {}
       fieldSelector[baseField] = slugBase
+
+      i = 0
+      while i < opts.distinctUpTo.length
+        f = opts.distinctUpTo[i]
+        fieldSelector[f] = doc[f]
+        i++
 
       sortSelector = {}
       sortSelector[indexField] = -1


### PR DESCRIPTION
This PR define a new option `distinctUpTo`, which is relevant only if `distinct = true`.

Business case: The slug have to be distinct not for the whole collection but only for the given user.
Example, we insert:

```
{title:'Title A', created_user_id:'U1' }
{title:'Title B', created_user_id:'U1' }
{title:'Title C', created_user_id:'U2' }
{title:'Title B', created_user_id:'U2' }
{title:'Title C', created_user_id:'U2' }
```

And the generated slugs are:

```
title-a
title-b
title-c
title-b
title-c-1
```

The URL will be *https://............/:user/:slug

Use of the new option:

``` coffee
    @pages_coll = new Mongo.Collection 'wiki_pages'
    @pages_coll.friendlySlugs { slugFrom: 'title', distinctUpTo: ['created_user_id'] }
```
