### PR TITLE
Allow user to pass slug generator as an option

### DIFF
--- a/slugs.coffee
+++ b/slugs.coffee
@@ -189,10 +189,13 @@ Mongo.Collection.prototype.friendlySlugs = (options = {}) ->
       else
         index = result.friendlySlugs[opts.slugField].index + 1
 
-      if index is 0
-        finalSlug = slugBase
-      else
-        finalSlug = slugBase + '-' + index
+      defaultSlugGenerator = (slugBase, index) ->
+        if index is 0 then slugBase else slugBase + '-' + index
+
+      slugGenerator = opts.slugGenerator ? defaultSlugGenerator
+
+      finalSlug = slugGenerator(slugBase, index)
+
     else
       #Not distinct, just set the base
       index = false


### PR DESCRIPTION
This allows the user to pass a `slugGenerator` option - a function that accepts the base slug and the index and returns the full slug. The original behavior is used as the default
